### PR TITLE
Make pfam2gff3 printing python2/3 compatible

### DIFF
--- a/pfam2gff.py
+++ b/pfam2gff.py
@@ -51,7 +51,7 @@ def cds_to_intervals(gtffile, keepexons, transdecoder, jgimode, nogenemode):
 	linecounter = 0
 	transcounter = 0
 	exoncounter = 0
-	sys.stderr.write("# Parsing gff from {}".format(gtffile)+" "+time.asctime())
+	sys.stderr.write("# Parsing gff from {}".format(gtffile)+" "+time.asctime()+os.linesep)
 	for line in open(gtffile).readlines():
 		line = line.strip()
 		if line: # ignore empty lines


### PR DESCRIPTION
pfam2gff3 now seems to be working under python3.

P.S.:

The 285 genes with domains extending beyond gene bounds cause for concern?
``` 
# Found 227092 domains for 26450 proteins Fri Mar  8 09:42:16 2019
# Wrote 127898 domain intervals Fri Mar  8 09:42:16 2019
# Removed 72022 domain hits by shortness Fri Mar  8 09:42:16 2019
# Removed 24077 domain hits by evalue Fri Mar  8 09:42:16 2019
# 285 genes have domains extending beyond gene bounds Fri Mar  8 09:42:16 2019
```

Lots of warnings on the stderr. 3450 by my count:
```
WARNING: cannot retrieve strand for Trinity_DN22028_c0_g1_i1.p2
WARNING: cannot retrieve strand for Trinity_DN19271_c0_g1_i1.p2
WARNING: cannot retrieve strand for Trinity_DN6146_c0_g1_i1.p2
WARNING: cannot retrieve strand for Trinity_DN16803_c0_g1_i1.p2
WARNING: cannot retrieve strand for Trinity_DN3418_c0_g3_i1.p2
WARNING: cannot retrieve strand for Trinity_DN3418_c0_g3_i12.p2
WARNING: cannot finish domain at 7009 for 24 in [(1024, 7173)]
WARNING: no intervals for zf-RanBP in Trinity_DN3418_c0_g3_i8.p1
WARNING: cannot finish domain at 7015 for 21 in [(1024, 7173)]
```

Here is my execution line
`python3 pfam2gff.py -g Trinity.transcripts.fasta.transdecoder.gff3 -i pfam_dom_annotations.txt -T > pfam_domains.gff3`


